### PR TITLE
Fix broken unicode support

### DIFF
--- a/src/corgit/corgit.csproj
+++ b/src/corgit/corgit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <VersionPrefix>0.2</VersionPrefix>
     <Authors>jzebedee</Authors>

--- a/src/corgit/corgit.csproj
+++ b/src/corgit/corgit.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>0.2</VersionPrefix>
+    <VersionPrefix>0.3</VersionPrefix>
     <Authors>jzebedee</Authors>
     <PackageProjectUrl>https://github.com/jzebedee/corgit</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/jzebedee/corgit/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/jzebedee/corgit</RepositoryUrl>
     <PackageTags>git corgit mingit git-for-windows libgit libgit2 libgit2sharp git.net git# gitsharp source-control scm</PackageTags>
     <Description>Minimal .NET Standard wrapper library to run and parse output from the git command-line utility</Description>
@@ -14,6 +14,12 @@
     <ProjectGuid>{35650b20-07fa-458b-bcc0-6ffbf185938a}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.2" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 </Project>

--- a/test/corgit.tests/corgit.tests.csproj
+++ b/test/corgit.tests/corgit.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
 

--- a/test/corgit.tests/corgit.tests.csproj
+++ b/test/corgit.tests/corgit.tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20190203-03" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Stdin was not being properly encoded as UTF-8 which led to munged commit messages. This was fixed, along with using Utf8NoBOM to avoid the BOMs that were included with the default UTF-8 encoding.

